### PR TITLE
check for go binary to in builder

### DIFF
--- a/JumpscaleBuildersExtra/storage/BuilderRestic.py
+++ b/JumpscaleBuildersExtra/storage/BuilderRestic.py
@@ -23,7 +23,8 @@ class BuilderRestic(BuilderGolangTools):
     def build(self, reset=False):
 
         # install golang dependancy
-        j.builders.runtimes.go.install()
+        if not j.sal.fs.exists("{DIR_BIN}/go"):
+            j.builders.runtimes.go.install(reset=True)
 
         cmd = self._replace(
             """


### PR DESCRIPTION
Add a check in building restic if go runtime builder is already done but go binary is missing from DIR_BIN/ to reinstall go runtime with reset=True.

This error happened in restic test (issue https://github.com/threefoldtech/jumpscaleX_core/issues/497)